### PR TITLE
Update OIDC scope

### DIFF
--- a/webhooks-api-v1-sample-nodejs-express-app/src/auth.ts
+++ b/webhooks-api-v1-sample-nodejs-express-app/src/auth.ts
@@ -21,7 +21,7 @@ export default class AuthService {
       client_id: config.ClientId,
       client_secret: config.ClientSecret,
       grant_type: "client_credentials",
-      scope: "webhooks:modify"
+      scope: "itwin-platform"
     };
   }
 

--- a/webhooks-api-v2-sample-azure-function/README.md
+++ b/webhooks-api-v2-sample-azure-function/README.md
@@ -12,7 +12,7 @@ This sample Azure Function:
 
 ## Prerequisites
 
-* Create "Service" type application in <https://developer.bentley.com/register/> with the scopes `webhooks:read` and `webhooks:modify`.
+* Create "Service" type application in <https://developer.bentley.com/register/> with the scope `itwin-platform`.
 * Create a webhook. Store this webhook's secret in the environment variable `WEBHOOK_SECRET`
 * [Git](https://git-scm.com/)
 * Visual Studio 2019/2022 or [Visual Studio Code](https://code.visualstudio.com/)

--- a/webhooks-api-v2-sample-azure-function/Services/AuthService.cs
+++ b/webhooks-api-v2-sample-azure-function/Services/AuthService.cs
@@ -9,17 +9,17 @@ using webhooks_api_v2_sample_azure_function.Services.Interfaces;
 
 namespace webhooks_api_v2_sample_azure_function.Services;
 
-public class AuthService: IAuthService
-    {
+public class AuthService : IAuthService
+{
     private readonly HttpClient _authHttpClient;
 
     public AuthService(IHttpClientFactory httpClientFactory)
-        {
+    {
         _authHttpClient = httpClientFactory.CreateClient();
-        }
+    }
 
     public async Task<string> GetAccessToken()
-        {
+    {
         var clientId = Environment.GetEnvironmentVariable("OAUTH_CLIENT_ID");
         var secret = Environment.GetEnvironmentVariable("OAUTH_CLIENT_SECRET");
 
@@ -27,7 +27,7 @@ public class AuthService: IAuthService
                     {
                 new KeyValuePair<string, string>("OAUTH_CLIENT_ID", clientId),
                 new KeyValuePair<string, string>("client_secret", secret),
-                new KeyValuePair<string, string>("scope", "webhooks:modify webhooks:read"),
+                new KeyValuePair<string, string>("scope", "itwin-platform"),
                 new KeyValuePair<string, string>("grant_type", "client_credentials"),
             });
 
@@ -37,6 +37,6 @@ public class AuthService: IAuthService
         var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(stringResponse);
 
         return tokenResponse.access_token;
-        }
     }
+}
 

--- a/webhooks-api-v2-sample-nodejs-express-app/src/auth.ts
+++ b/webhooks-api-v2-sample-nodejs-express-app/src/auth.ts
@@ -21,7 +21,7 @@ export default class AuthService {
       client_id: config.ClientId,
       client_secret: config.ClientSecret,
       grant_type: "client_credentials",
-      scope: "webhooks:read webhooks:modify"
+      scope: "itwin-platform"
     };
   }
 


### PR DESCRIPTION
iTwin Platform has reduced scopes to a single `itwin-platform` to provide simpler and more streamlined experience. The samples have been updated to reflect this.